### PR TITLE
gem: Update nokogiri beyond 1.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,14 +158,14 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
     minitest (5.10.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
@@ -202,4 +202,4 @@ DEPENDENCIES
   jekyll-paginate
 
 BUNDLED WITH
-   1.11.2
+   1.16.0


### PR DESCRIPTION
See:
  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050